### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
   def index
     @items = Item.order("created_at DESC").includes(:user)
+    # @item = Item.find(params[:id])
   end
 
   def new
@@ -17,8 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
-  #def show
-  #end
+  def show
+    @item = Item.find(params[:id])
+    @user = User.find(params[:id])
+  end
 
   #def edit
   #end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,7 +20,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @user = User.find(params[:id])
   end
 
   #def edit

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,14 +123,15 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <% link_to items_path , class: "subtitle" %>
+    <%= link_to '#' , class: "subtitle" %>
     <ul class='item-lists'>
       <%if Item.exists?%>
         <% @items.each do |item| %>
       <li class='list'>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img"  %>
-
+        <%end%>
 
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -149,10 +150,10 @@
             </div>
           </div>
         </div>
+        <%end%>
       </li>
-    <% end %>
-
-    <%else%>
+      <%else%>
+   
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -168,8 +169,9 @@
             </div>
           </div>
         </div>
-        <% end %>
         <%end%>
+        <%end%>
+       
       </li>
     </ul>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,25 +16,24 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in?%> 
+      <%if current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <%elsif '商品が出品中かどうか'%>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <%end%>
+      <%end%>
 
     <div class="item-explain-box">
       <span><%= @item.description_of_item %></span>
@@ -43,7 +42,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.name.name %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.user_id %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @user.nickname %></td>
+          <td class="detail-value"><%= @item.user.user_id %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -102,7 +102,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:index,:create,:new]
+  resources :items, only: [:index,:create,:new,:show]
 end


### PR DESCRIPTION
# What

商品詳細表示機能の実装

# Why

ユーザーが商品一覧の詳細を知るため

# Other

ログアウト中のユーザでも、商品詳細ページはみることができる。が編集・消去・購入ボタンが表示されない

https://gyazo.com/dc3d46b541b26b5258c7034ce7c7d2aa

ログイン中出品者のみ、編集・消去ボタンが表示される

https://gyazo.com/4bccdf4b9568e2c7b8c1f5f09e2df2c1

ログイン状態の出品者以外のユーザーのみが、購入に進むボタンが表示される

https://gyazo.com/30addab779068e06f7a62256751333da




