### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :log_user_edit, only: [:edit,:update]
-  before_action :set_item
+  before_action :set_item, only: [:show,:edit,:update]
   before_action :authenticate_user!, except: [:index,:show]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :log_user_edit, only: :edit
-  before_action :itemmer
+  before_action :log_user_edit, only: [:edit,:update]
+  before_action :set_item
   before_action :authenticate_user!, except: [:index,:show]
 
   def index
@@ -47,7 +47,7 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name,:price,:description_of_item,:prefecture_id,:product_condition_id,:date_of_shipment_id,:shipping_charge_id,:category_id,:image).merge(user_id: current_user.id)
   end
 
-  def itemmer 
+  def set_item 
     @item = Item.find(params[:id])
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :log_user_edit, only: :edit
-  before_action :authenticate_user!, only: [:new,:edit]
+  before_action :itemmer
+  before_action :authenticate_user!, except: [:index,:show]
 
   def index
     @items = Item.order("created_at DESC").includes(:user)
@@ -12,7 +13,7 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    @saves=if @item.save
+    if @item.save
       redirect_to root_path
     else
       render :new
@@ -20,11 +21,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
@@ -48,9 +47,12 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name,:price,:description_of_item,:prefecture_id,:product_condition_id,:date_of_shipment_id,:shipping_charge_id,:category_id,:image).merge(user_id: current_user.id)
   end
 
+  def itemmer 
+    @item = Item.find(params[:id])
+  end
+
 
   def log_user_edit
-    @item = Item.find(params[:id])
     if current_user.id != @item.user_id
       redirect_to root_path
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :log_user_edit, only: :edit
+  before_action :authenticate_user!, only: [:new,:edit]
 
   def index
     @items = Item.order("created_at DESC").includes(:user)
@@ -27,8 +28,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item = Item.find(params[:id])
-     if @item.update(item_params)
+    if @item.update(item_params)
       redirect_to item_path
      else
       render :edit
@@ -49,5 +49,10 @@ class ItemsController < ApplicationController
   end
 
 
+  def log_user_edit
+    @item = Item.find(params[:id])
+    if current_user.id != @item.user_id
+      redirect_to root_path
+    end
+  end
 end
-

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    if @item.save
+    @saves=if @item.save
       redirect_to root_path
     else
       render :new
@@ -22,16 +22,25 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  #def edit
-  #end
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+     if @item.update(item_params)
+      redirect_to item_path
+     else
+      render :edit
+     end
+    end
 
 
-  #def destroy
-    #if @item.destroy
-      #redirect_to root_path
-    #else
-     # redirect_to root_path
-   # end
+ # def destroy
+   # item = Item.find(params[:id])
+    #if item.destroy(item_params)
+     #redirect_to root_path
+    #end
   #end
 
   private

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -38,7 +38,7 @@ class OrdersController < ApplicationController
   end
 
   def log_user_show
-    if current_user == @item.user_id? || @item.purchase.present?
+    if current_user == @item.user_id || @item.purchase.present?
       redirect_to root_path
     end
   end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,14 +1,17 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item,url: items_path,local: true do |f| %>
+    <%= form_with model: @item,local: true do |f| %>
 
 
-    <%= render 'shared/error_messages', model: f.object %>
+<%= render 'shared/error_messages', model: f.object %>
+
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -49,7 +52,7 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, Category.all, :id, :name, {prompt: ""}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id,Category.all, :id, :name, {prompt: ""}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
@@ -70,12 +73,12 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charge_id,ShippingCharge.all, :id, :name, {prompt: ""}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {prompt: ""}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {prompt: ""}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id,Prefecture.all, :id, :name, {prompt: ""}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
@@ -110,8 +113,8 @@
           <span>販売利益</span>
           <span>
             <span id='profit'></span>円
+          </span>
         </div>
-        </span>
       </div>
     </div>
     <%# /販売価格 %>
@@ -137,8 +140,8 @@
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "出品する",class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -44,6 +44,7 @@
           で使いやすい
         </h3>
         <p class='reason-list-description'>
+        
           めんどくさい入力は必要なく、検索も購入もスムーズ！
         </p>
       </li>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
 
     <% if user_signed_in? && @item.purchase.blank?%> 
       <%if current_user.id == @item.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集',edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index,:create,:new,:show] do
+  resources :items do
     resources :orders, only: [:index,:create]
   end
 end


### PR DESCRIPTION
# What

商品情報編集機能の実装

# Why

出品ユーザーが自身の出品した商品を編集できるようにする為

# Other

何も編集せずに更新をしても画像なしの商品にならないこと

https://gyazo.com/48990b3741b481befc956287ada1d005

必要な情報を適切に入力すると、商品情報を変更できること

https://gyazo.com/f8a9d2281b099f980fec6861865c1491

ログイン状態の出品者だけが商品情報ページに遷移できる、つまりログイン状態の出品者以外が
urlを直接入力して出品していない商品の編集ページへ遷移しようとすると、トップページへ

https://gyazo.com/22877fb55d80969543633c82de647887

ログアウトユーザーはurlを直接入力して商品情報ページへ遷移しようとするとログインページへ

https://gyazo.com/8a601f5cd175106cf4b1e79ebedb6b23

商品名など既に登録されている情報は商品情報編集画面で開いた時点で表示されること

https://gyazo.com/cd14b8c5a7a20ab3ca49af8f058c09e9

エラーハンドリングができているかどうか、そして出力は商品情報編集ページにて行われているか

https://gyazo.com/72c6adca2826b852ff10e78299b499ca